### PR TITLE
Update .env.sample to use different connection strings

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,2 @@
 DATABASE_URL="postgres://daniel:<password>@ep-damp-cell-18160816.us-east-2.aws.neon.tech/neondb"
-DATABASE_REPLICA_URL="postgres://daniel:<password>@ep-damp-cell-18160816.us-east-2.aws.neon.tech/neondb"
+DATABASE_REPLICA_URL="postgres://daniel:<password>@ep-raspy-cherry-95040071.us-east-2.aws.neon.tech/neondb"


### PR DESCRIPTION
Use a different connection string for the read replica to indicate that it's a different compute instance/database than the read-write. This will always be the case with Neon Postgres.